### PR TITLE
Count missing syscalls for a binary 

### DIFF
--- a/utils/list_implemented_syscalls.sh
+++ b/utils/list_implemented_syscalls.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# this script should display one implemented syscall per line
+# it assumes libc-ns3.h only implements one syscall per line
+# this line removes C/C++ comments
+file="../model/libc-ns3.h"
+
+if [ $# -gt 1 ]; then
+	file="$1"
+fi
+
+# preprocess file with gcc to remove C/C++ comments
+# use 'lookaround' regex patterns to select name within parentheses
+# http://unix.stackexchange.com/questions/103004/grep-regex-only-for-match-anything-between-parenthesis
+gcc -fpreprocessed -E "$file" | grep -E "DCE|NATIVE" | grep -Po '(?<=\().*(?=\))' 

--- a/utils/list_implemented_syscalls.sh
+++ b/utils/list_implemented_syscalls.sh
@@ -2,7 +2,7 @@
 # this script should display one implemented syscall per line
 # it assumes libc-ns3.h only implements one syscall per line
 # this line removes C/C++ comments
-file="../model/libc-ns3.h"
+file="$(dirname ${BASH_SOURCE:-$0})/../model/libc-ns3.h"
 
 if [ $# -gt 1 ]; then
 	file="$1"

--- a/utils/missing_syscalls.sh
+++ b/utils/missing_syscalls.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# output the last K lines, instead of the last 10; or use -n +K to output lines starting with the Kth
+# ./elfread ~/dce/build/bin/ntpd | tail -n +5 | wc -l 
+if [ $# -lt 1 ]; then
+	echo "Use: $0 <binary>"
+	exit 1
+fi
+scriptdir=$(dirname "${BASH_SOURCE:-$0}")
+binary="$1"
+tail -n +5 <("$scriptdir/elfread" "$binary") | grep -Fxv -f <("$scriptdir/list_implemented_syscalls.sh")


### PR DESCRIPTION
In order to evaluate the potential support of a program by DCE, it is important to know what syscalls are missing. Related to https://github.com/direct-code-execution/ns-3-dce/issues/1