### PR TITLE
Fixes https://www.nsnam.org/bugzilla/show_bug.cgi?id=2098

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -26,7 +26,7 @@ New user-visible features
 
 Bugs fixed
 ----------
--
+- Bug 2098 - DCE_PATH and DCE_ROOT are now taken into account by DCE
 
 
 Release dce-1.7

--- a/doc/source/dce-user-newapps.rst
+++ b/doc/source/dce-user-newapps.rst
@@ -20,7 +20,7 @@ Install the target executable
 ------------------------------
 
 Copy the executable file produced in a specified directory in the variable environment DCE_PATH so that DCE can find it.
-(FIXME: to be updated)
+DCE_PATH behaves like the variable PATH and can contain several directories such as ``/home/USER/iproute2/ip:/home/USER/iperf3/src:/home/USER/iperf2/src``
 
 Write a |ns3| script
 --------------------

--- a/test.py
+++ b/test.py
@@ -656,9 +656,14 @@ def make_paths():
         os.environ["LD_LIBRARY_PATH"] += ":" + dce_ldlibpath
         if options.verbose:
             print "os.environ[\"LD_LIBRARY_PATH\"] == %s" % os.environ["LD_LIBRARY_PATH"]
-        os.environ["DCE_PATH"] = os.environ["LD_LIBRARY_PATH"]
-        os.environ['DCE_ROOT'] = os.pathsep.join([os.path.join(NS3_BUILDDIR), \
-                                                os.path.join(NS3_INSTALL_DIR)])
+
+        dce_paths = [os.getenv('DCE_PATH'), os.environ["LD_LIBRARY_PATH"] ]
+        os.environ["DCE_PATH"] = os.pathsep.join(filter(None, dce_paths))
+
+        dce_roots = [os.getenv('DCE_ROOT'), \
+                     os.path.join(NS3_BUILDDIR), \
+                     os.path.join(NS3_INSTALL_DIR)]
+        os.environ['DCE_ROOT'] = os.pathsep.join(filter(None, dce_roots))
 
 #
 # Short note on generating suppressions:

--- a/wutils.py
+++ b/wutils.py
@@ -107,14 +107,17 @@ def get_proc_env(os_env=None):
                                              os.path.join(bld.env.NS3_DIR, 'lib64'), \
                                              os.path.join(bld.env.NS3_DIR, 'bin')])
 
+    dce_paths = [os.getenv('DCE_PATH'), \
+            os.path.join(bld.out_dir, 'bin_dce'), \
+            os.path.join(bld.env.NS3_DIR, 'sbin'), \
+            os.path.join(bld.env.NS3_DIR, 'bin_dce'), \
+            proc_env[pathvar]]
+    proc_env['DCE_PATH'] = os.pathsep.join(filter(None, dce_paths))
 
-    proc_env['DCE_PATH'] = os.pathsep.join([os.path.join(bld.out_dir, 'bin_dce'), \
-                                                os.path.join(bld.env.NS3_DIR, 'sbin'), \
-                                                os.path.join(bld.env.NS3_DIR, 'bin_dce'), \
-                                                proc_env[pathvar]])
-
-    proc_env['DCE_ROOT'] = os.pathsep.join([os.path.join(bld.out_dir), \
-                                                os.path.join(bld.env.PREFIX)])
+    dce_roots = [os.getenv('DCE_ROOT'), \
+            os.path.join(bld.out_dir), \
+            os.path.join(bld.env.PREFIX)]
+    proc_env['DCE_ROOT'] = os.pathsep.join(filter(None, dce_roots))
 
     pymoddir = bld.path.find_dir('bindings/python')
     if pymoddir is not None:


### PR DESCRIPTION
The documentation (https://www.nsnam.org/docs/dce/manual/html/dce-user-newapps.html) says
"Copy the executable file produced in a specified directory in the
variable environment DCE_PATH so that DCE can find it. (FIXME: to be
updated)" but wutils.py was overriding the user DCE_PATH and DCE_ROOT.

This patch prepends the user exported values for these 2 environment
variables.