### PR TITLE
mkstemp should modify the suffix part "XXXXXX" of its argument so that

### DIFF
--- a/model/dce-stdlib.cc
+++ b/model/dce-stdlib.cc
@@ -89,6 +89,8 @@ int dce_atexit (void (*function)(void))
 }
 
 // XXX: run function to runall atexit functions
+/* The last six characters of temp must be the suffix "XXXXXX".
+ This suffix is then replaced with a string that makes the filename unique */
 int dce_mkstemp (char *temp)
 {
   Thread *current = Current ();
@@ -97,10 +99,16 @@ int dce_mkstemp (char *temp)
 
   std::string fullpath = UtilsGetRealFilePath (temp);
   NS_LOG_FUNCTION (fullpath);
-  int realFd = mkstemp ((char *)fullpath.c_str ());
+
+  char* c_fullpath = new char[fullpath.length()+1];
+  fullpath.copy (c_fullpath, fullpath.length());
+  c_fullpath[fullpath.length()] = '\0';
+
+  int realFd = mkstemp (c_fullpath);
   if (realFd == -1)
     {
       current->err = errno;
+      delete c_fullpath;
       return -1;
     }
 
@@ -108,18 +116,23 @@ int dce_mkstemp (char *temp)
   if (fd == -1)
     {
       current->err = EMFILE;
+      delete c_fullpath;
       return -1;
     }
   UnixFd *unixFd = 0;
   unixFd = new UnixFileFd (realFd);
   unixFd->IncFdCount ();
   current->process->openFiles[fd] = new FileUsage (fd, unixFd);
+
+  strncpy (temp, &c_fullpath[strlen(c_fullpath)-strlen(temp)], strlen(temp));
+  delete c_fullpath;
   return fd;
 }
 
 FILE * dce_tmpfile (void)
 {
-  int fd = dce_mkstemp ((char *)"temp");
+  char filename[] = "tempXXXXXX";
+  int fd = dce_mkstemp (filename);
   return dce_fdopen (fd, "w+");
 }
 

--- a/test/test-stdlib.cc
+++ b/test/test-stdlib.cc
@@ -17,8 +17,30 @@ static void test_strtod (void)
   TEST_ASSERT_EQUAL (retval, 2000);
 }
 
+static void test_mkstemp(void)
+{
+    /* dce_mkstemp */
+    int ret = 0;
+    std::string suffix = "XXXXXX";
+    std::string prefix = "test";
+    std::string oldFilename = prefix + suffix;
+    const std::size_t filenamelen = 30;
+    char filename[filenamelen];
+    strncpy (filename, oldFilename.c_str(), filenamelen - 1);
+    filename[oldFilename.size() - 1] = '\0';
+    ret = mkstemp (filename);
+    std::string newFilename (filename);
+    std::clog << "filename " << filename << std::endl;
+
+    /* test that the suffix part was actually changed and the prefix untouched */
+    TEST_ASSERT_EQUAL (newFilename.substr (0,4), prefix);
+    TEST_ASSERT_UNEQUAL (newFilename.substr (prefix.size()), suffix);
+
+}
+
 int main (int argc, char *argv[])
 {
   test_strtod ();
+  test_mkstemp ();
   return 0;
 }


### PR DESCRIPTION
the caller gets the correct filename.

This fixed the indentation in dce_tmpfile.