### PR TITLE
Fix various warnings with latest gcc

### DIFF
--- a/example/udp-echo-client.cc
+++ b/example/udp-echo-client.cc
@@ -30,7 +30,7 @@ int main (int argc, char *argv[])
   size_t bLen = 1 + strlen (argv[2]);
   char *buffer = (char *)malloc (bLen);
 
-  memset (buffer, 0, sizeof (buffer));
+  memset (buffer, 0, bLen*sizeof (char));
 
   socklen_t aLen = sizeof(addr);
 

--- a/model/dce-fd.cc
+++ b/model/dce-fd.cc
@@ -320,7 +320,7 @@ ssize_t dce_writev (int fd, const struct iovec *iov, int iovcnt)
     }
 
   void *buf = malloc (count);
-  void *bufp = buf;
+  char *bufp = (char *)buf;
   for (int i = 0; i < iovcnt; ++i)
     {
       memcpy (bufp, iov[i].iov_base, iov[i].iov_len);

--- a/model/dce-netdb.cc
+++ b/model/dce-netdb.cc
@@ -407,6 +407,7 @@ map_newlink (int index, struct ifaddrs_storage *ifas, int *map, int max)
   /* This should never be reached. If this will be reached, we have
      a very big problem.  */
   dce_abort ();
+  return 0;
 }
 
 static void

--- a/model/dce-string.cc
+++ b/model/dce-string.cc
@@ -24,7 +24,7 @@ char * dce___strcpy_chk (char *__restrict __dest,
                          size_t __destlen)
 {
   /// \todo Do actual checking
-  strcpy (__dest, __src);
+  return strcpy (__dest, __src);
 }
 
 char * dce_strpbrk (const char *s, const char *a)

--- a/model/dce-syslog.cc
+++ b/model/dce-syslog.cc
@@ -44,6 +44,7 @@ dce_setlogmask (int maskpri)
   NS_LOG_FUNCTION (Current () << UtilsGetNodeId () << maskpri);
   NS_ASSERT (Current () != 0);
   // ignore
+  return 0;
 }
 
 void

--- a/model/elf-dependencies.cc
+++ b/model/elf-dependencies.cc
@@ -101,7 +101,7 @@ ElfDependencies::GatherDependencies (std::string fullname) const
   int ret = system (lddCmd.str ().c_str ());
   if (ret == -1)
     {
-      NS_LOG_ERROR (lddCmd << " failed");
+      NS_LOG_ERROR (lddCmd.str () << " failed");
       return dependencies;
     }
 

--- a/model/local-datagram-socket-fd.cc
+++ b/model/local-datagram-socket-fd.cc
@@ -731,7 +731,7 @@ LocalDatagramSocketFd::Sendmsg (const struct msghdr *msg, int flags)
     {
       uint8_t *buf = (uint8_t *) msg->msg_iov[i].iov_base;
       ssize_t len = msg->msg_iov[i].iov_len;
-      size_t ret = 0;
+      int ret = 0;
 
       while (m_state < REMOTECLOSED)
         {
@@ -888,6 +888,9 @@ LocalDatagramSocketFd::RemoveConnected (LocalDatagramSocketFd *freeOne, bool and
           }
       }
       break;
+    default:
+        NS_LOG_WARN ("Unhandled case");
+        break;
     }
 }
 

--- a/test/netlink-socket-test.cc
+++ b/test/netlink-socket-test.cc
@@ -434,7 +434,7 @@ void
 NetlinkSocketTestCase::ReceiveMulticastPacket (Ptr<Socket> socket)
 {
   Ptr<Packet> packet;
-  while (packet = socket->Recv ())
+  while ((packet = socket->Recv ()))
     {
       MultipartNetlinkMessage nlmsg;
       packet->RemoveHeader (nlmsg);

--- a/test/test-stdio.cc
+++ b/test/test-stdio.cc
@@ -64,9 +64,9 @@ static void test_fopen (void)
 
 static void test_freadwrite (void)
 {
-  char buffer[] = {
-    static_cast<char>(0xff), static_cast<char>(0xfe), static_cast<char>(0xfd), static_cast<char>(0x00),
-    static_cast<char>(0x02), static_cast<char>(0x05), static_cast<char>(0x12), static_cast<char>(0x15)
+  unsigned char buffer[] = {
+    0xff, 0xfe, 0xfd, 0x00,
+    0x02, 0x05, 0x12, 0x15
   };
   int status;
   status = unlink ("X");
@@ -157,9 +157,9 @@ void test_seek (void)
   // cleanup
   unlink ("X");
   // let's write a file
-  char buffer[] = {
-    static_cast<char>(0xff), static_cast<char>(0xfe), static_cast<char>(0xfd), static_cast<char>(0x00),
-    static_cast<char>(0x02), static_cast<char>(0x05), static_cast<char>(0x12), static_cast<char>(0x15)
+  unsigned char buffer[] = {
+    0xff, 0xfe, 0xfd, 0x00,
+    0x02, 0x05, 0x12, 0x15
   };
   FILE *file;
   file = fopen ("X", "w+");


### PR DESCRIPTION
When updating ubuntu, gcc5 got installed and would stop compiling DCE because of some warnings.