### PR TITLE
dce_gettime now returns the node time

### DIFF
--- a/model/dce-time.cc
+++ b/model/dce-time.cc
@@ -18,7 +18,9 @@ time_t dce_time (time_t *t)
 {
   NS_LOG_FUNCTION (Current () << UtilsGetNodeId ());
   NS_ASSERT (Current () != 0);
-  time_t time = (time_t)UtilsSimulationTimeToTime (Now ()).GetSeconds ();
+
+  Time nodeTime = UtilsNodeTime(UtilsGetNodeId ());
+  time_t time = (time_t)UtilsSimulationTimeToTime (nodeTime).GetSeconds ();
   if (t != 0)
     {
       *t = time;
@@ -67,9 +69,11 @@ int dce_clock_gettime (clockid_t c, struct timespec *tp)
       Current ()->err = EFAULT;
       return -1;
     }
-  *tp = UtilsTimeToTimespec (UtilsSimulationTimeToTime (Now ()));
+  Time t = UtilsNodeTime(UtilsGetNodeId ());
+  *tp = UtilsTimeToTimespec (UtilsSimulationTimeToTime (t));
   return 0;
 }
+
 void dce_tzset ()
 {
 

--- a/model/dce-time.h
+++ b/model/dce-time.h
@@ -11,11 +11,18 @@
 extern "C" {
 #endif
 
+/**
+* \return seconds since EPOCH
+*/
 time_t dce_time (time_t *t);
 struct tm * dce_gmtime (const time_t *timep);
 struct tm * dce_localtime (const time_t *timep);
 char * dce_ctime (const time_t *timep);
 char * dce_asctime (const struct tm *tm);
+/**
+ * \brief
+ * \warn does not distinguish between clock ids (CLOCK_REALTIME etc...)
+ */
 int dce_clock_gettime (clockid_t which_clock, struct timespec *tp);
 int dce_sysinfo (struct sysinfo *info);
 void dce_tzset (void);

--- a/model/utils.cc
+++ b/model/utils.cc
@@ -14,14 +14,20 @@
 #include <list>
 #include <fcntl.h>
 #include <unistd.h>
+#include "dce-unistd.h"
 #include "file-usage.h"
 #include "ns3/global-value.h"
 #include "ns3/uinteger.h"
+#include "ns3/node-list.h"
+#include "ns3/node.h"
 
 NS_LOG_COMPONENT_DEFINE ("ProcessUtils");
 
 namespace ns3 {
 
+/**
+ * \brief Set the epoch of the simulation
+ */
 GlobalValue g_timeBase = GlobalValue ("SimulationTimeBase",
                                       "The timebase for this simulation",
                                       // January 1st, 2010, 00:00:00
@@ -153,6 +159,31 @@ struct timespec UtilsTimeToTimespec (Time time)
   tv.tv_nsec = n % 1000000000;
   return tv;
 }
+
+std::string
+UtilsGenerateIfNameFromIndex(uint32_t i) {
+    std::stringstream ss;
+    ss <<  "ns3-device " << i;
+    return ss.str();
+}
+
+Ptr<Node>
+UtilsGetNode(uint32_t nodeId)
+{
+  Ptr<Node> node(NodeList::GetNode(nodeId));
+  NS_ASSERT(node);
+  return node;
+}
+
+Time
+UtilsNodeTime(uint32_t nodeId)
+{
+  Ptr<Node> node(UtilsGetNode(nodeId));
+  Time t = node->GetLocalTime();
+  t = UtilsSimulationTimeToTime (t);
+  return t;
+}
+
 Time UtilsSimulationTimeToTime (Time time)
 {
   UintegerValue uintegerValue;

--- a/model/utils.h
+++ b/model/utils.h
@@ -27,29 +27,70 @@ namespace ns3 {
 
 class Thread;
 class Process;
+class Node;
 
 // Little hack in order to have a context usable when disposing the Task Manager and the hidden goal is to flush the open FILEs.
 extern Thread *gDisposingThreadContext;
 
+/**
+Create directory
+*/
 void UtilsEnsureDirectoryExists (std::string realPath);
+
+/**
+Will create all the directories in the path successively
+*/
 void UtilsEnsureAllDirectoriesExist (std::string realPath);
+/**
+\return "files-<nodeId>/path"
+*/
 std::string UtilsGetRealFilePath (std::string path);
+
+/*
+Same as UtilsGetRealFilePath excepts that it creates files-<nodeId> if it does not exist
+*/
 std::string UtilsGetAbsRealFilePath (uint32_t node, std::string path);
+
+/**
+\return absolute path from the node point of view.
+*/
 std::string UtilsGetVirtualFilePath (std::string path);
 uint32_t UtilsGetNodeId (void);
+
+/**
+ * Get time of the node. To use with UtilsGetNodeId()
+ */
+Time UtilsNodeTime(uint32_t nodeId);
+Ptr<Node> UtilsGetNode(uint32_t nodeId);
+
 Thread * Current (void);
 bool HasPendingSignal (void);
 Time UtilsTimeToSimulationTime (Time time);
+
+/**
+* \brief translate ns3 time to epoch defined by GlobalValue "SimulationTimeBase"
+* \see SimulationTimeBase
+*/
 Time UtilsSimulationTimeToTime (Time time);
+
+
+/**
+* \brief Converts ns3 Time to linux timeval structure
+* \see UtilsTimevalToTime
+*/
 struct timeval UtilsTimeToTimeval (Time time);
 struct timespec UtilsTimeToTimespec (Time time);
+
 Time UtilsTimespecToTime (struct timespec tm);
 Time UtilsTimevalToTime (struct timeval tv);
 Time UtilsTimevalToTime (const struct timeval *tv);
 void UtilsSendSignal (Process *process, int signum);
 void UtilsDoSignal (void);
 int UtilsAllocateFd (void);
-// Little hack to advance time when detecting a possible infinite loop.
+
+/**
+ * \brief Little hack to advance time when detecting a possible infinite loop.
+ */
 void UtilsAdvanceTime (Thread *current);
 std::string GetTimeStamp ();
 bool CheckExeMode (struct stat *st, uid_t uid, gid_t gid);
@@ -64,8 +105,13 @@ bool CheckShellScript (std::string fileName,
 char * seek_env (const char *name, char **array);
 std::string UtilsGetCurrentDirName (void);
 
+
+/* helpful to get consistent interface names since ns3 has no convention yet */
+std::string UtilsGenerateIfNameFromIndex(uint32_t i);
+
 #define MAX_FDS 1024
 
+/* there must be a 'fd' variable in the outer scope */
 #define OPENED_FD_METHOD_ERR(errCode, rettype, args) \
   std::map < int,FileUsage * > ::iterator it = current->process->openFiles.find (fd); \
   if (current->process->openFiles.end () == it) \
@@ -90,6 +136,10 @@ std::string UtilsGetCurrentDirName (void);
 \
   return retval;
 
+/**
+ * \param args should be a member of UnixFd
+ * \return -1 in case of error
+ */
 #define OPENED_FD_METHOD(rettype, args) OPENED_FD_METHOD_ERR (-1, rettype, args)
 
 } // namespace ns3


### PR DESCRIPTION
ns3 introduced Node::GetLocalTime to return a node specific time. This
leverages this feature.

I've added some documentation more or less in a  doxygen style. Let me know if that's fine.
This should work as is but if you prefer, you may want to leave this PR pending until I get a full patch with ntp examples etc...