### PR TITLE
Fixes for clang 3.6.2-1

### DIFF
--- a/example/ccnx/dce-ccn-cache.cc
+++ b/example/ccnx/dce-ccn-cache.cc
@@ -179,7 +179,7 @@ void InstallGetters (NodeContainer nodes)
         {
           int nodeNum = GetNodes [n];
 
-          if ((onlySomeNodes &&  (nodeNum == 13) || (nodeNum == 39))||(!onlySomeNodes))
+          if (((onlySomeNodes &&  (nodeNum == 13)) || (nodeNum == 39))||(!onlySomeNodes))
             {
 
               getNumber++;

--- a/example/dce-iperf-heterogeneous-multihop.cc
+++ b/example/dce-iperf-heterogeneous-multihop.cc
@@ -204,9 +204,9 @@ main (int argc, char *argv[])
   // ----------------------------------------------------------------------
   // Make left side fast connection and assign addresses (10.1.i.*/24)
   // ----------------------------------------------------------------------
-  NetDeviceContainer linkL[numRouters/2];
+  std::vector<NetDeviceContainer> linkL;
 
-  linkL[0] = fastLink.Install  (client, routersL.Get(0));
+  linkL.push_back(fastLink.Install  (client, routersL.Get(0)));
   address.SetBase ("10.1.0.0", "255.255.255.0");
   address.Assign (linkL[0]);
 
@@ -215,7 +215,7 @@ main (int argc, char *argv[])
   // ----------------------------------------------------------------------
   for(int i=1; i<numRouters/2; i++)
     {
-      linkL[i] = slowLink.Install (routersL.Get(i-1), routersL.Get(i));
+      linkL.push_back(slowLink.Install (routersL.Get(i-1), routersL.Get(i)));
 
       std::ostringstream oss;
       oss << "10.1." << i << ".0";
@@ -235,11 +235,11 @@ main (int argc, char *argv[])
   // ----------------------------------------------------------------------
   // Make extra right side slow connections and assign addresses (10.1.i.*/24)
   // ----------------------------------------------------------------------
-  NetDeviceContainer linkR[numRouters/2];
+  std::vector<NetDeviceContainer> linkR;
 
   for(int i=1; i<numRouters/2; i++)
     {
-      linkR[i] = slowLink.Install (routersR.Get(i-1), routersR.Get(i));
+      linkR.push_back(slowLink.Install (routersR.Get(i-1), routersR.Get(i)));
 
       std::ostringstream oss;
       oss << "10.3." << i << ".0";

--- a/example/udp-echo-client.cc
+++ b/example/udp-echo-client.cc
@@ -42,7 +42,7 @@ int main (int argc, char *argv[])
 
     if (wLen > 0)
       {
-        memset (buffer, 0, sizeof(buffer));
+        memset (buffer, 0, bLen);
         ssize_t n = read (sock, buffer, bLen);
 
         if (n > 0)

--- a/model/dce-dl.cc
+++ b/model/dce-dl.cc
@@ -61,4 +61,5 @@ void *dce_dlsym(void *handle, const char *symbol)
 
 int dce_dlclose(void *handle)
 {
+    return 0;
 }

--- a/model/dce-manager.cc
+++ b/model/dce-manager.cc
@@ -74,7 +74,9 @@ DceManager::GetTypeId (void)
     .SetParent<Object> ()
     .AddConstructor<DceManager> ()
     .AddTraceSource ("Exit", "A process has exited",
-                     MakeTraceSourceAccessor (&DceManager::m_processExit))
+                     MakeTraceSourceAccessor (&DceManager::m_processExit),
+                     "ns3::DceManager::ProcessExitTracedCallback"
+                     )
     .AddAttribute ("FirstPid", "The PID used by default when creating a process in this manager.",
                    UintegerValue (1),
                    MakeUintegerAccessor (&DceManager::m_nextPid),

--- a/model/linux/linux-socket-impl.cc
+++ b/model/linux/linux-socket-impl.cc
@@ -218,6 +218,9 @@ LinuxSocketImpl::GetSocketType (void) const
     default:
         break;
     }
+
+    // To remove compiler warning
+    return NS3_SOCK_RAW;
 }
 
 uint16_t

--- a/model/wait-queue.cc
+++ b/model/wait-queue.cc
@@ -35,6 +35,10 @@ WaitQueueEntry::WaitQueueEntry ()
 {
 }
 
+WaitQueueEntry::~WaitQueueEntry ()
+{
+}
+
 WaitQueueEntryPoll::WaitQueueEntryPoll (Callback<void> cb) : m_func (cb)
 {
 }

--- a/model/wait-queue.h
+++ b/model/wait-queue.h
@@ -44,7 +44,7 @@ class WaitQueueEntry
 {
 public:
   WaitQueueEntry ();
-  // virtual ~WaitQueueEntry ();
+  virtual ~WaitQueueEntry ();
 
   // Wake Up the waiter of some events
   // \param key: generic parameter describing the event source

--- a/myscripts/ccn-common/my-serveur.c
+++ b/myscripts/ccn-common/my-serveur.c
@@ -10,6 +10,8 @@
 #include <errno.h>
 #include <netdb.h>
 #include <poll.h>
+#include <time.h>
+#include <sys/time.h>
 
 struct a_client
 {
@@ -192,9 +194,9 @@ int main (int argc, char **argv)
                 }
             }
         }
-      printf ("%d: --> poll j=%d\n",time(NULL), j );
+      printf ("%lu: --> poll j=%d\n",time(NULL), j );
       int ret = poll (fds, j, 29000 * 1000);
-      printf ("%d: poll --> %d\n", time(NULL), ret);
+      printf ("%lu: poll --> %d\n", time(NULL), ret);
 
       if (ret <= 0)
         {

--- a/myscripts/loaders-test/mylib.cc
+++ b/myscripts/loaders-test/mylib.cc
@@ -12,6 +12,7 @@ int init_thing ()
     {
       good = -45;
     }
+    return 0;
 }
 
 int get_thing ()

--- a/netlink/netlink-socket.cc
+++ b/netlink/netlink-socket.cc
@@ -93,7 +93,8 @@ NetlinkSocket::GetTypeId (void)
     .SetParent<Socket> ()
     .AddConstructor<NetlinkSocket> ()
     .AddTraceSource ("Drop", "Drop packet due to receive buffer overflow",
-                     MakeTraceSourceAccessor (&NetlinkSocket::m_dropTrace))
+                     MakeTraceSourceAccessor (&NetlinkSocket::m_dropTrace),
+                     "ns3::NetlinkSocket::PacketTracedCallback")
     .AddAttribute ("RcvBufSize",
                    "NetlinkSocket maximum receive buffer size (bytes)",
                    UintegerValue (0xffffffffl),

--- a/test/netlink-socket-test.cc
+++ b/test/netlink-socket-test.cc
@@ -422,7 +422,7 @@ void
 NetlinkSocketTestCase::ReceiveUnicastPacket (Ptr<Socket> socket)
 {
   Ptr<Packet> packet;
-  while (packet = socket->Recv ())
+  while ((packet = socket->Recv ()))
     {
       MultipartNetlinkMessage nlmsg;
       packet->RemoveHeader (nlmsg);


### PR DESCRIPTION
- Missing parenthesis
- complained not having virtual destructor
- "error: variable length array of non-POD element type"
- missing returned values
- add missing includes