### PR TITLE
Adds netlink pcap export

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -28,7 +28,7 @@ Bugs fixed
 ----------
 - Bug 2098 - DCE_PATH and DCE_ROOT are now taken into account by DCE
 - github #5  Allow to override values returned by DceNodeContext::UName #5
-
+- github issue#2 - dce_getifaddrs() now returns a correct result
 
 Release dce-1.7
 ===============

--- a/model/cmsg.h
+++ b/model/cmsg.h
@@ -1,19 +1,50 @@
 #include <stdint.h>
 #include <sys/socket.h>
+#include <iostream>
 
 namespace ns3 {
 
+/**
+ * \brief Structure used for storage of ancillary data object information (Control message header wrapper)
+ *
+ * These messages are not a part of the socket payload and may include the interface
+ * the packet was received on, various rarely used header fields,
+ * an extended error description, a set of file descriptors or UNIX credentials.
+ * Ancillary data is a sequence of struct cmsghdr structures with appended data.
+ */
 class Cmsg
 {
 public:
   Cmsg (struct msghdr *msg);
-  void Add (int level, int type, int len, const uint8_t *buffer);
+
+  /**
+   * Generate the cmsghdr accordingly
+   *
+   * \return True if there is enough space to add ancillary data
+   */
+  bool Add (int level, int type, int len, const uint8_t *buffer);
+
+  /**
+   * Get next control message
+   *
+   * \return <0 in case of failure, 0 if successful
+   */
   int GetNext (int *level, int *type, int *len, uint8_t **buffer);
+
+  /**
+   * Updates parameters of m_msg
+   */
   void Finish (void);
+
+
+  void Print (std::ostream &os) const;
+
 private:
-  struct msghdr *m_msg;
-  uint8_t *m_current;
-  int m_len;
+  struct msghdr *m_msg; /**< describes messages sent by `sendmsg' and received by `recvmsg' */
+  uint8_t *m_current;   /**< points at where to add anciliary data */
+  int m_len;            /**< Length as defined in constructor NOTE: socket.h has a warning about this datatype */
 };
+
+std::ostream& operator<< (std::ostream& os, const Cmsg & address);
 
 } // namespace ns3

--- a/model/utils.cc
+++ b/model/utils.cc
@@ -153,6 +153,14 @@ struct timespec UtilsTimeToTimespec (Time time)
   tv.tv_nsec = n % 1000000000;
   return tv;
 }
+
+std::string
+UtilsGenerateIfNameFromIndex(uint32_t i) {
+    std::stringstream ss;
+    ss <<  "ns3-device " << i;
+    return ss.str();
+}
+
 Time UtilsSimulationTimeToTime (Time time)
 {
   UintegerValue uintegerValue;

--- a/model/utils.h
+++ b/model/utils.h
@@ -64,6 +64,12 @@ bool CheckShellScript (std::string fileName,
 char * seek_env (const char *name, char **array);
 std::string UtilsGetCurrentDirName (void);
 
+
+/** ns3 does not name interfaces but some applications using netlink expect consistent
+ * interface naming hence DCE propose its scheme.
+ */
+std::string UtilsGenerateIfNameFromIndex(uint32_t i);
+
 #define MAX_FDS 1024
 
 #define OPENED_FD_METHOD_ERR(errCode, rettype, args) \

--- a/netlink/netlink-attribute.cc
+++ b/netlink/netlink-attribute.cc
@@ -277,10 +277,27 @@ NetlinkAttributeValue::GetSize () const
   return len;
 }
 
+std::string
+NetlinkAttribute::TypeToStr(NetlinkAttributeValueType type)
+{
+  static const char* str[] = {
+    "UNSPEC", // invalid initial value.
+  "U8",
+  "U16",
+  "U32",
+  "U64",
+  "STRING",
+  "ADDRESS"
+  };
+
+  NS_ASSERT(type >= UNSPEC && type <= ADDRESS);
+  return str[type];
+}
+
 void
 NetlinkAttributeValue::Print (std::ostream &os) const
 {
-  os << "NetlinkAttributeValue (type= " << m_type << ", v= ";
+  os << "NetlinkAttributeValue (type= " << NetlinkAttribute::TypeToStr(m_type) << ", v= ";
   if (m_type == U8)
     {
       os << m_u8;
@@ -400,7 +417,7 @@ NetlinkAttribute::Print (std::ostream &os) const
      << "type: " << m_type << " "
      << "payload:[";
   m_payload.Print (os);
-  os << "]";
+  os << "]" << std::endl;
 }
 
 uint32_t

--- a/netlink/netlink-attribute.h
+++ b/netlink/netlink-attribute.h
@@ -44,7 +44,7 @@ typedef enum NetlinkAttributeValueType_e
   U64,
   STRING,
   ADDRESS,
-}NetlinkAttributeValueType;
+} NetlinkAttributeValueType;
 
 class NetlinkAttributeValue
 {
@@ -98,6 +98,8 @@ public:
   NetlinkAttribute (uint16_t type, NetlinkAttributeValueType payloadtype,  uint64_t payload);
   NetlinkAttribute (uint16_t type, NetlinkAttributeValueType payloadtype,  std::string payload);
   NetlinkAttribute (uint16_t type, NetlinkAttributeValueType payloadtype,  Address payload);
+
+  static std::string TypeToStr(NetlinkAttributeValueType type);
 
   //static TypeId GetTypeId (void);
   //virtual TypeId GetInstanceTypeId (void) const;

--- a/netlink/netlink-message-route.cc
+++ b/netlink/netlink-message-route.cc
@@ -24,6 +24,48 @@
 
 namespace ns3 {
 
+std::string NetlinkRtmTypeToStr(int type)
+{
+  static const char* str[] = {
+  "GETLINK",
+  "SETLINK",
+
+  "NEWADDR",
+  "DELADDR",
+  "GETADDR",
+
+  "NEWROUTE",
+  "DELROUTE",
+  "GETROUTE"
+  };
+
+  NS_ASSERT(type > NETLINK_RTM_BASE && type < NETLINK_RTM_MAX);
+  return str[type-NETLINK_RTM_GETLINK];
+
+}
+
+std::string NetlinkFamilyToStr(int family)
+{
+  static const char* str[] = {
+  "BASE",
+  "GETLINK",
+  "SETLINK",
+
+  "NEWADDR",
+  "DELADDR",
+  "GETADDR",
+
+  "NEWROUTE",
+  "DELROUTE",
+  "GETROUTE"
+  };
+
+  NS_ASSERT(family >= 0 && family < 30);
+  return str[family];
+
+}
+
+
 /***********************************************************************************
 * \ NetlinkPayload
 ***********************************************************************************/

--- a/netlink/netlink-message-route.h
+++ b/netlink/netlink-message-route.h
@@ -60,6 +60,11 @@ enum NetlinkRtmType_e
   NETLINK_RTM_MAX,
 };
 
+/*
+NETLINK_RTM_BASE
+*/
+std::string NetlinkRtmTypeToStr(int);
+
 /**
 * \Types of netlink groups,here we only define types quagga used
 */

--- a/netlink/netlink-message.cc
+++ b/netlink/netlink-message.cc
@@ -458,7 +458,7 @@ NetlinkMessage::Print (std::ostream &os) const
 
   if (type == NETLINK_MSG_DONE)
     {
-      os << "multipart message ends here";
+      os << "\nmultipart message ends here";
     }
   else if (type == NETLINK_MSG_ERROR)
     {
@@ -606,6 +606,7 @@ MultipartNetlinkMessage::Print (std::ostream &os) const
   for (uint32_t i = 0; i <  m_netlinkMessages.size (); i++)
     {
       m_netlinkMessages[i].Print (os);
+      os << std::endl;
     }
 }
 uint32_t

--- a/netlink/netlink-message.h
+++ b/netlink/netlink-message.h
@@ -42,7 +42,7 @@ class MultipartNetlinkMessage;
 There are three levels to a Netlink message: The general Netlink
 message header, the IP service specific template, and the IP service
 specific data.
-
+\verbatim
 0                   1                   2                   3
 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
@@ -58,6 +58,7 @@ specific data.
 |                  IP Service specific data in TLVs             |
 |                                                               |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+\endverbatim
 */
 
 enum NetlinkMessageFlag
@@ -96,6 +97,13 @@ class NetlinkMessageHeader : public ObjectBase
 {
 public:
   NetlinkMessageHeader ();
+
+  /**
+   * \param type Should be of type NetlinkMessageType
+   * \param flags
+   * \param seq Sequence number
+   * \param pid Processus id
+   */
   NetlinkMessageHeader (uint16_t type, uint16_t flags, uint32_t seq, uint32_t pid);
 
   static TypeId GetTypeId (void);
@@ -125,12 +133,20 @@ private:
   uint16_t m_nlmsgType; /* Message content */
   uint16_t m_nlmsgFlags;        /* Additional flags */
   uint32_t m_nlmsgSeq;  /* Sequence number */
-  uint32_t m_nlmsgPid;  /* Sending process PID */
+
+  /*
+   * Portd ID (PID)
+   * The port number specifies the peer to which the message should be delivered to.
+   * If not specified, the message will be delivered to the first matching
+   * kernel side socket of the same protocol family.
+   * \see http://www.infradead.org/~tgr/libnl/doc/core.html#core_addressing
+   */
+  uint32_t m_nlmsgPid;
 };
 
 /**
-* \brief The struct nlmsgerr
-*/
+ * \brief The struct nlmsgerr
+ */
 class NetlinkMessageError : public NetlinkPayload
 {
 public:
@@ -156,6 +172,10 @@ private:
 };
 
 
+/**
+ * Netlink messages consist of a byte stream with one or multiple nlmsghdr
+ * headers  and  associated  payload.
+ */
 class NetlinkMessage : public ObjectBase
 {
 public:
@@ -230,6 +250,13 @@ private:
   RouteMessage m_routeTemplate;
 };
 
+/**
+ * Excerpt of manpage:
+ In  multipart  messages  (multiple  nlmsghdr  headers  with  associated
+       payload in one byte stream) the first and all  following  headers  have
+       the NLM_F_MULTI flag set, except for the last header which has the type
+       NLMSG_DONE.
+ */
 class MultipartNetlinkMessage : public Header
 {
 public:

--- a/netlink/netlink-socket-factory.cc
+++ b/netlink/netlink-socket-factory.cc
@@ -22,6 +22,12 @@
 #include "netlink-socket-factory.h"
 #include "netlink-socket.h"
 #include "ns3/node.h"
+#include "ns3/log.h"
+
+#include "ns3/trace-helper.h"
+#include <sstream>
+
+NS_LOG_COMPONENT_DEFINE ("DceNetlinkSocketFactory");
 
 namespace ns3 {
 
@@ -43,6 +49,7 @@ NetlinkSocketFactory::NetlinkSocketFactory ()
 
 Ptr<Socket> NetlinkSocketFactory::CreateSocket (void)
 {
+  NS_LOG_FUNCTION_NOARGS();
   Ptr<Node> node = GetObject<Node> ();
   Ptr<NetlinkSocket> socket = CreateObject<NetlinkSocket> ();
   socket->SetNode (node);

--- a/test/netlink-socket-test.cc
+++ b/test/netlink-socket-test.cc
@@ -33,8 +33,11 @@
 #include "ns3/assert.h"
 #include "ns3/log.h"
 #include "ns3/socket.h"
+#include "ns3/pcap-file.h"
+#include "ns3/pcap-file-wrapper.h"
 #include "netlink-message.h"
 #include "netlink-socket-address.h"
+#include "netlink-socket.h"
 #include <sys/socket.h>
 #include <string>
 #include <list>
@@ -550,6 +553,14 @@ NetlinkSocketTestCase::DoRun (void)
   addr.SetProcessID (m_pid + 1);
   addr.SetGroupsMask (NETLINK_RTM_GRP_IPV4_IFADDR | NETLINK_RTM_GRP_IPV4_ROUTE);
   m_groupSock->Bind (addr);
+
+
+
+  PcapHelper pcapHelper;
+  std::string filename = "netlink-test.pcap";
+  Ptr<PcapFileWrapper> file = pcapHelper.CreateFile (filename, std::ios::out, PcapHelper::DLT_NETLINK);
+  // for now we test only one socket
+  pcapHelper.HookDefaultSink<NetlinkSocket> (DynamicCast<NetlinkSocket>(m_cmdSock), "PromiscSniffer", file);
 
   /*test 1: for Serialize and Deserialize*/
   TestNetlinkSerialization ();


### PR DESCRIPTION
-This adds a "PromiscSniffer" callback in the netlink socket that can be
used to export netlink packets.
-Also fixes a netlink bug where pid was sent incorrectly (Issue #2).
-Also complete the netlink answer returned by getifaddr, otherwise ntpd
would discard it.
-provides an interface naming convention with UtilsGenerateIfNameFromIndex

This is linked to this issue:
https://github.com/direct-code-execution/ns-3-dce/issues/2

You can see the generated pcap via the test:
./waf --run "test-runner --test-name=netlink-socket --verbose"

Wireshark won't be able to decode it automatically: to do that one would need to prepend it with sll headers. If this patch gets merged, then I will move https://codereview.appspot.com/276320043 to DCE as the necessary ns3 modifications are too heavy.

