### PR TITLE
Better default for uname.

### DIFF
--- a/model/dce-manager.cc
+++ b/model/dce-manager.cc
@@ -89,7 +89,7 @@ DceManager::GetTypeId (void)
                    MakeBooleanChecker ())
     .AddAttribute ("UnameStringRelease",
                    "release member of struct utsname returned by uname(2).",
-                   StringValue ("3"),
+                   StringValue ("3.2.3"),
                    MakeStringAccessor (&DceManager::m_release),
                    MakeStringChecker ())
     .AddAttribute ("UnameStringVersion",


### PR DESCRIPTION
Some programs such as chrony fail when they can't parse uname.release,
for instance:
if (sscanf(uts.release, "%d.%d.%d", &major, &minor, &patch) < 2) {