### PR TITLE
Issue 15: mention checksums in hybrid simulations

### DIFF
--- a/doc/source/dce-user-kernel.rst
+++ b/doc/source/dce-user-kernel.rst
@@ -98,6 +98,12 @@ The next step would be writing |ns3| simulation scenario to use the applications
    apps = process.Install (nodes.Get (1));
    apps.Start (Seconds (1.5));
 
+**Optional**
+When running hybrid simulations, i.e. with both kernel and ns3 stacks, the kernel will drop packets with invalid checksums. You can enable ns3 checksums globally:
+
+  1. if you pass the argument '--ChecksumEnabled=1' to any program that includes CommandLine parsing.
+  2. if you export the environment variable NS_GLOBAL_VALUE="ChecksumEnabled=1" before launching your simulation
+
 5. run it !
 --------
 


### PR DESCRIPTION
In case of hybrid simulations Kernel drops packets (e.g. sends RST) if ns3 checksums are disabled.
Add a mention in documentation.

I am not sure it's the best place to put the mention ?

== EDIT
Hybrid simulations refer to simulations involving both ns and linux or BSD stacks. I would like to raise in the doc points of importance to get reasonable results.
- [x] ns Checksums need to be enabled
- [ ] ns3 callbacks don't get called https://github.com/direct-code-execution/ns-3-dce/issues/24
- [ ] List ns attributes that need to change (Dunno if an ns3 page exist, for instance ns3 and linux TCP RTOs differ).
