### PR TITLE
Prefix all loggers with DCE to ease log filtering

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -23,6 +23,7 @@ Tested platforms
 
 New user-visible features
 -------------------------
+- All logger names start with Dce. DceAlloc got renamed to DceKingsleyAlloc
 
 Bugs fixed
 ----------

--- a/example/ccnx/dce-ccn-cache.cc
+++ b/example/ccnx/dce-ccn-cache.cc
@@ -15,7 +15,7 @@
 
 using namespace ns3;
 
-NS_LOG_COMPONENT_DEFINE ("CcnCache");
+NS_LOG_COMPONENT_DEFINE ("DceCcnCache");
 
 std::vector<int> GetNodes;
 int middleNode = 0;

--- a/example/ccnx/dce-ccnd-linear-multiple.cc
+++ b/example/ccnx/dce-ccnd-linear-multiple.cc
@@ -40,7 +40,7 @@ using namespace ns3;
 // node 0 put a file and node X get the file
 //
 //
-NS_LOG_COMPONENT_DEFINE ("CcndInLine");
+NS_LOG_COMPONENT_DEFINE ("DceCcndInLine");
 
 void
 CreateReadme ()

--- a/example/ccnx/dce-tap-ccnd.cc
+++ b/example/ccnx/dce-tap-ccnd.cc
@@ -80,7 +80,7 @@
 
 using namespace ns3;
 
-NS_LOG_COMPONENT_DEFINE ("TapCCND");
+NS_LOG_COMPONENT_DEFINE ("DceTapCCND");
 
 void
 CreateReadme ()

--- a/example/ccnx/dce-tap-udp-echo.cc
+++ b/example/ccnx/dce-tap-udp-echo.cc
@@ -65,7 +65,7 @@
 
 using namespace ns3;
 
-NS_LOG_COMPONENT_DEFINE ("TapUDPEcho");
+NS_LOG_COMPONENT_DEFINE ("DceTapUDPEcho");
 
 int
 main (int argc, char *argv[])

--- a/example/ccnx/dce-wifi-ccnx.cc
+++ b/example/ccnx/dce-wifi-ccnx.cc
@@ -38,7 +38,7 @@
 
 
 
-NS_LOG_COMPONENT_DEFINE ("dce-wifi-ccnx");
+NS_LOG_COMPONENT_DEFINE ("DceWifiCcnx");
 
 using namespace ns3;
 

--- a/helper/ccn-client-helper.cc
+++ b/helper/ccn-client-helper.cc
@@ -6,7 +6,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 
-NS_LOG_COMPONENT_DEFINE ("CcnClientHelper");
+NS_LOG_COMPONENT_DEFINE ("DceCcnClientHelper");
 
 namespace ns3 {
 

--- a/helper/ipv4-dce-routing-helper.cc
+++ b/helper/ipv4-dce-routing-helper.cc
@@ -31,7 +31,7 @@
 #include "../model/ipv4-dce-routing.h"
 #include "ipv4-dce-routing-helper.h"
 
-NS_LOG_COMPONENT_DEFINE ("Ipv4DceRoutingHelper");
+NS_LOG_COMPONENT_DEFINE ("DceIpv4DceRoutingHelper");
 
 namespace ns3 {
 

--- a/model/cooja-loader-factory.cc
+++ b/model/cooja-loader-factory.cc
@@ -34,7 +34,7 @@ struct SharedModule
 
 namespace ns3 {
 
-NS_LOG_COMPONENT_DEFINE ("CoojaLoaderFactory");
+NS_LOG_COMPONENT_DEFINE ("DceCoojaLoaderFactory");
 NS_OBJECT_ENSURE_REGISTERED (CoojaLoaderFactory);
 
 struct SharedModules

--- a/model/dce-alloc.cc
+++ b/model/dce-alloc.cc
@@ -6,7 +6,7 @@
 #include "ns3/log.h"
 #include <string.h>
 
-NS_LOG_COMPONENT_DEFINE ("SimuAlloc");
+NS_LOG_COMPONENT_DEFINE ("DceAlloc");
 
 using namespace ns3;
 

--- a/model/dce-cxa.cc
+++ b/model/dce-cxa.cc
@@ -4,7 +4,7 @@
 #include "ns3/assert.h"
 #include "ns3/log.h"
 
-NS_LOG_COMPONENT_DEFINE ("SimuCxa");
+NS_LOG_COMPONENT_DEFINE ("DceCxa");
 
 using namespace ns3;
 

--- a/model/dce-debug.cc
+++ b/model/dce-debug.cc
@@ -9,7 +9,7 @@
 
 using namespace ns3;
 
-NS_LOG_COMPONENT_DEFINE ("SimuDebug");
+NS_LOG_COMPONENT_DEFINE ("DceDebug");
 
 static std::list<uint32_t> g_dce_debug_nodes;
 

--- a/model/dce-env.cc
+++ b/model/dce-env.cc
@@ -5,7 +5,7 @@
 #include "ns3/assert.h"
 #include <string.h>
 
-NS_LOG_COMPONENT_DEFINE ("SimuEnv");
+NS_LOG_COMPONENT_DEFINE ("DceEnv");
 
 using namespace ns3;
 

--- a/model/dce-fd.cc
+++ b/model/dce-fd.cc
@@ -32,7 +32,7 @@
 #include "dce-stdlib.h"
 #include "pipe-fd.h"
 
-NS_LOG_COMPONENT_DEFINE ("SimuFd");
+NS_LOG_COMPONENT_DEFINE ("DceFd");
 
 
 #ifdef _K_SS_MAXSIZE

--- a/model/dce-poll.cc
+++ b/model/dce-poll.cc
@@ -11,7 +11,7 @@
 #include <map>
 
 
-NS_LOG_COMPONENT_DEFINE ("PollSelect");
+NS_LOG_COMPONENT_DEFINE ("DcePollSelect");
 
 using namespace ns3;
 

--- a/model/dce-pthread-cond.cc
+++ b/model/dce-pthread-cond.cc
@@ -6,7 +6,7 @@
 #include "ns3/assert.h"
 #include <errno.h>
 
-NS_LOG_COMPONENT_DEFINE ("SimuPthreadCond");
+NS_LOG_COMPONENT_DEFINE ("DcePthreadCond");
 
 using namespace ns3;
 

--- a/model/dce-pthread-mutex.cc
+++ b/model/dce-pthread-mutex.cc
@@ -7,7 +7,7 @@
 #include <stdint.h>
 #include <errno.h>
 
-NS_LOG_COMPONENT_DEFINE ("PthreadMutex");
+NS_LOG_COMPONENT_DEFINE ("DcePthreadMutex");
 
 using namespace ns3;
 

--- a/model/dce-pthread.cc
+++ b/model/dce-pthread.cc
@@ -15,7 +15,7 @@
 #include <signal.h>
 #include <list>
 
-NS_LOG_COMPONENT_DEFINE ("SimuPthread");
+NS_LOG_COMPONENT_DEFINE ("DcePthread");
 
 using namespace ns3;
 

--- a/model/dce-semaphore.cc
+++ b/model/dce-semaphore.cc
@@ -9,7 +9,7 @@
 #include "ns3/fatal-error.h"
 #include "ns3/simulator.h"
 
-NS_LOG_COMPONENT_DEFINE ("Semaphore");
+NS_LOG_COMPONENT_DEFINE ("DceSemaphore");
 
 using namespace ns3;
 

--- a/model/dce-signal.cc
+++ b/model/dce-signal.cc
@@ -7,7 +7,7 @@
 #include <vector>
 #include <errno.h>
 
-NS_LOG_COMPONENT_DEFINE ("SimuSignal");
+NS_LOG_COMPONENT_DEFINE ("DceSignal");
 
 using namespace ns3;
 

--- a/model/dce-stat.cc
+++ b/model/dce-stat.cc
@@ -10,7 +10,7 @@
 
 using namespace ns3;
 
-NS_LOG_COMPONENT_DEFINE ("SimuStat");
+NS_LOG_COMPONENT_DEFINE ("DceStat");
 
 int dce___xstat (int ver, const char *path, struct stat *buf)
 {

--- a/model/dce-stdlib.cc
+++ b/model/dce-stdlib.cc
@@ -10,7 +10,7 @@
 #include <limits.h>
 
 
-NS_LOG_COMPONENT_DEFINE ("SimuStdlib");
+NS_LOG_COMPONENT_DEFINE ("DceStdlib");
 
 using namespace ns3;
 

--- a/model/dce-termio.cc
+++ b/model/dce-termio.cc
@@ -7,7 +7,7 @@
 #include <vector>
 #include <errno.h>
 
-NS_LOG_COMPONENT_DEFINE ("SimuTermio");
+NS_LOG_COMPONENT_DEFINE ("DceTermio");
 
 using namespace ns3;
 

--- a/model/dce-timerfd.cc
+++ b/model/dce-timerfd.cc
@@ -7,7 +7,7 @@
 #include "file-usage.h"
 using namespace ns3;
 
-NS_LOG_COMPONENT_DEFINE ("SimuTimerFd");
+NS_LOG_COMPONENT_DEFINE ("DceTimerFd");
 
 int dce_timerfd_create (int clockid, int flags)
 {

--- a/model/dce-umask.cc
+++ b/model/dce-umask.cc
@@ -7,7 +7,7 @@
 
 using namespace ns3;
 
-NS_LOG_COMPONENT_DEFINE ("SimuUmask");
+NS_LOG_COMPONENT_DEFINE ("DceUmask");
 
 mode_t dce_umask (mode_t mask)
 {

--- a/model/dce-wait.cc
+++ b/model/dce-wait.cc
@@ -9,7 +9,7 @@
 #include <errno.h>
 #include <vector>
 
-NS_LOG_COMPONENT_DEFINE ("SimuWait");
+NS_LOG_COMPONENT_DEFINE ("DceWait");
 
 using namespace ns3;
 

--- a/model/dlm-loader-factory.cc
+++ b/model/dlm-loader-factory.cc
@@ -4,7 +4,7 @@
 #include <list>
 #include <dlfcn.h>
 
-NS_LOG_COMPONENT_DEFINE ("DlmLoaderFactory");
+NS_LOG_COMPONENT_DEFINE ("DceDlmLoaderFactory");
 
 extern "C" {
 // The function and structure declarations below are not exactly equal to the

--- a/model/elf-cache.cc
+++ b/model/elf-cache.cc
@@ -13,7 +13,7 @@
 
 namespace ns3 {
 
-NS_LOG_COMPONENT_DEFINE ("ElfCache");
+NS_LOG_COMPONENT_DEFINE ("DceElfCache");
 
 ElfCache::ElfCache (std::string directory, uint32_t uid)
   : m_directory (directory),

--- a/model/elf-dependencies.cc
+++ b/model/elf-dependencies.cc
@@ -18,7 +18,7 @@
 
 namespace ns3 {
 
-NS_LOG_COMPONENT_DEFINE ("ElfDependencies");
+NS_LOG_COMPONENT_DEFINE ("DceElfDependencies");
 
 ElfDependencies::ElfDependencies (std::string filename, bool failsafe)
 {

--- a/model/elf-ldd.cc
+++ b/model/elf-ldd.cc
@@ -43,7 +43,7 @@
 namespace ns3 {
 using namespace std;
 
-NS_LOG_COMPONENT_DEFINE ("ElfLdd");
+NS_LOG_COMPONENT_DEFINE ("DceElfLdd");
 
 class SharedLibrary
 {

--- a/model/fifo-buffer.cc
+++ b/model/fifo-buffer.cc
@@ -23,7 +23,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-NS_LOG_COMPONENT_DEFINE ("FifoBuffer");
+NS_LOG_COMPONENT_DEFINE ("DceFifoBuffer");
 
 #define MIN_ALLOC 1024
 

--- a/model/file-usage.cc
+++ b/model/file-usage.cc
@@ -22,7 +22,7 @@
 #include "ns3/log.h"
 #include "unix-fd.h"
 
-NS_LOG_COMPONENT_DEFINE ("FileUsage");
+NS_LOG_COMPONENT_DEFINE ("DceFileUsage");
 
 namespace ns3 {
 FileUsage::FileUsage (int fd, UnixFd *file)

--- a/model/freebsd-socket-fd-factory.cc
+++ b/model/freebsd-socket-fd-factory.cc
@@ -9,7 +9,7 @@
 #include "ns3/simulator.h"
 #include "ns3/node.h"
 
-NS_LOG_COMPONENT_DEFINE ("FreeBSDSocketFdFactory");
+NS_LOG_COMPONENT_DEFINE ("DceFreeBSDSocketFdFactory");
 
 namespace ns3 {
 NS_OBJECT_ENSURE_REGISTERED (FreeBSDSocketFdFactory);

--- a/model/freebsd/ipv4-freebsd.cc
+++ b/model/freebsd/ipv4-freebsd.cc
@@ -37,7 +37,7 @@
 #include "freebsd-dccp-socket-factory-impl.h"
 #endif
 
-NS_LOG_COMPONENT_DEFINE ("Ipv4FreeBSD");
+NS_LOG_COMPONENT_DEFINE ("DceIpv4FreeBSD");
 
 
 namespace ns3 {

--- a/model/ipv4-dce-routing.cc
+++ b/model/ipv4-dce-routing.cc
@@ -36,7 +36,7 @@
 #include "../netlink/netlink-socket.h"
 
 
-NS_LOG_COMPONENT_DEFINE ("Ipv4DceRouting");
+NS_LOG_COMPONENT_DEFINE ("DceIpv4DceRouting");
 
 using std::make_pair;
 

--- a/model/kernel-socket-fd-factory.cc
+++ b/model/kernel-socket-fd-factory.cc
@@ -34,7 +34,7 @@
 #include <arpa/inet.h>
 #include <fcntl.h>
 
-NS_LOG_COMPONENT_DEFINE ("KernelSocketFdFactory");
+NS_LOG_COMPONENT_DEFINE ("DceKernelSocketFdFactory");
 
 namespace ns3 {
 

--- a/model/kernel-socket-fd.cc
+++ b/model/kernel-socket-fd.cc
@@ -8,7 +8,7 @@
 #include <sys/mman.h> // for MMAP_FAILED
 #include <poll.h>
 
-NS_LOG_COMPONENT_DEFINE ("KernelSocketFd");
+NS_LOG_COMPONENT_DEFINE ("DceKernelSocketFd");
 
 namespace ns3 {
 

--- a/model/kingsley-alloc.cc
+++ b/model/kingsley-alloc.cc
@@ -5,7 +5,7 @@
 #include "ns3/assert.h"
 #include "ns3/log.h"
 
-NS_LOG_COMPONENT_DEFINE ("Alloc");
+NS_LOG_COMPONENT_DEFINE ("DceKingsleyAlloc");
 
 #ifdef HAVE_VALGRIND_H
 # include "valgrind/valgrind.h"

--- a/model/linux-socket-fd-factory.cc
+++ b/model/linux-socket-fd-factory.cc
@@ -10,7 +10,7 @@
 #include "ns3/node.h"
 
 
-NS_LOG_COMPONENT_DEFINE ("LinuxSocketFdFactory");
+NS_LOG_COMPONENT_DEFINE ("DceLinuxSocketFdFactory");
 
 namespace ns3 {
 NS_OBJECT_ENSURE_REGISTERED (LinuxSocketFdFactory);

--- a/model/linux/ipv4-linux.cc
+++ b/model/linux/ipv4-linux.cc
@@ -35,7 +35,7 @@
 #include "linux-dccp-socket-factory-impl.h"
 #include "linux-sctp-socket-factory-impl.h"
 
-NS_LOG_COMPONENT_DEFINE ("Ipv4Linux");
+NS_LOG_COMPONENT_DEFINE ("DceIpv4Linux");
 
 namespace ns3 {
 

--- a/model/linux/ipv6-linux.cc
+++ b/model/linux/ipv6-linux.cc
@@ -32,7 +32,7 @@
 #include "linux-dccp6-socket-factory-impl.h"
 #include "linux-sctp6-socket-factory-impl.h"
 
-NS_LOG_COMPONENT_DEFINE ("Ipv6Linux");
+NS_LOG_COMPONENT_DEFINE ("DceIpv6Linux");
 
 namespace ns3 {
 

--- a/model/linux/linux-dccp-socket-factory-impl.cc
+++ b/model/linux/linux-dccp-socket-factory-impl.cc
@@ -25,7 +25,7 @@
 #include <netinet/in.h>
 #include <arpa/inet.h>
 
-NS_LOG_COMPONENT_DEFINE ("LinuxDccpSocketFactoryImpl");
+NS_LOG_COMPONENT_DEFINE ("DceLinuxDccpSocketFactoryImpl");
 
 namespace ns3 {
 

--- a/model/linux/linux-dccp6-socket-factory-impl.cc
+++ b/model/linux/linux-dccp6-socket-factory-impl.cc
@@ -25,7 +25,7 @@
 #include <netinet/in.h>
 #include <arpa/inet.h>
 
-NS_LOG_COMPONENT_DEFINE ("LinuxDccp6SocketFactoryImpl");
+NS_LOG_COMPONENT_DEFINE ("DceLinuxDccp6SocketFactoryImpl");
 
 namespace ns3 {
 

--- a/model/linux/linux-ipv4-raw-socket-factory-impl.cc
+++ b/model/linux/linux-ipv4-raw-socket-factory-impl.cc
@@ -25,7 +25,7 @@
 #include <netinet/in.h>
 #include <arpa/inet.h>
 
-NS_LOG_COMPONENT_DEFINE ("LinuxIpv4RawSocketFactoryImpl");
+NS_LOG_COMPONENT_DEFINE ("DceLinuxIpv4RawSocketFactoryImpl");
 
 namespace ns3 {
 

--- a/model/linux/linux-ipv6-raw-socket-factory-impl.cc
+++ b/model/linux/linux-ipv6-raw-socket-factory-impl.cc
@@ -25,7 +25,7 @@
 #include <netinet/in.h>
 #include <arpa/inet.h>
 
-NS_LOG_COMPONENT_DEFINE ("LinuxIpv6RawSocketFactoryImpl");
+NS_LOG_COMPONENT_DEFINE ("DceLinuxIpv6RawSocketFactoryImpl");
 
 namespace ns3 {
 

--- a/model/linux/linux-sctp-socket-factory-impl.cc
+++ b/model/linux/linux-sctp-socket-factory-impl.cc
@@ -25,7 +25,7 @@
 #include <netinet/in.h>
 #include <arpa/inet.h>
 
-NS_LOG_COMPONENT_DEFINE ("LinuxSctpSocketFactoryImpl");
+NS_LOG_COMPONENT_DEFINE ("DceLinuxSctpSocketFactoryImpl");
 
 namespace ns3 {
 

--- a/model/linux/linux-sctp6-socket-factory-impl.cc
+++ b/model/linux/linux-sctp6-socket-factory-impl.cc
@@ -25,7 +25,7 @@
 #include <netinet/in.h>
 #include <arpa/inet.h>
 
-NS_LOG_COMPONENT_DEFINE ("LinuxSctp6SocketFactoryImpl");
+NS_LOG_COMPONENT_DEFINE ("DceLinuxSctp6SocketFactoryImpl");
 
 namespace ns3 {
 

--- a/model/linux/linux-socket-impl.cc
+++ b/model/linux/linux-socket-impl.cc
@@ -39,7 +39,7 @@
 #include "ns3/inet-socket-address.h"
 #include "ns3/inet6-socket-address.h"
 
-NS_LOG_COMPONENT_DEFINE ("LinuxSocketImpl");
+NS_LOG_COMPONENT_DEFINE ("DceLinuxSocketImpl");
 
 namespace ns3 {
 

--- a/model/linux/linux-tcp-socket-factory-impl.cc
+++ b/model/linux/linux-tcp-socket-factory-impl.cc
@@ -25,7 +25,7 @@
 #include <netinet/in.h>
 #include <arpa/inet.h>
 
-NS_LOG_COMPONENT_DEFINE ("LinuxTcpSocketFactoryImpl");
+NS_LOG_COMPONENT_DEFINE ("DceLinuxTcpSocketFactoryImpl");
 
 namespace ns3 {
 

--- a/model/linux/linux-tcp6-socket-factory-impl.cc
+++ b/model/linux/linux-tcp6-socket-factory-impl.cc
@@ -25,7 +25,7 @@
 #include <netinet/in.h>
 #include <arpa/inet.h>
 
-NS_LOG_COMPONENT_DEFINE ("LinuxTcp6SocketFactoryImpl");
+NS_LOG_COMPONENT_DEFINE ("DceLinuxTcp6SocketFactoryImpl");
 
 namespace ns3 {
 

--- a/model/linux/linux-udp-socket-factory-impl.cc
+++ b/model/linux/linux-udp-socket-factory-impl.cc
@@ -25,7 +25,7 @@
 #include <netinet/in.h>
 #include <arpa/inet.h>
 
-NS_LOG_COMPONENT_DEFINE ("LinuxUdpSocketFactoryImpl");
+NS_LOG_COMPONENT_DEFINE ("DceLinuxUdpSocketFactoryImpl");
 
 namespace ns3 {
 

--- a/model/linux/linux-udp6-socket-factory-impl.cc
+++ b/model/linux/linux-udp6-socket-factory-impl.cc
@@ -25,7 +25,7 @@
 #include <netinet/in.h>
 #include <arpa/inet.h>
 
-NS_LOG_COMPONENT_DEFINE ("LinuxUdp6SocketFactoryImpl");
+NS_LOG_COMPONENT_DEFINE ("DceLinuxUdp6SocketFactoryImpl");
 
 namespace ns3 {
 

--- a/model/local-datagram-socket-fd.cc
+++ b/model/local-datagram-socket-fd.cc
@@ -34,7 +34,7 @@
 #include "wait-queue.h"
 #include <unistd.h>
 
-NS_LOG_COMPONENT_DEFINE ("LocalDatagramSocketFd");
+NS_LOG_COMPONENT_DEFINE ("DceLocalDatagramSocketFd");
 
 namespace ns3 {
 TypeId

--- a/model/local-socket-fd-factory.cc
+++ b/model/local-socket-fd-factory.cc
@@ -26,7 +26,7 @@
 #include "ns3/log.h"
 #include <map>
 
-NS_LOG_COMPONENT_DEFINE ("LocalSocketFdFactory");
+NS_LOG_COMPONENT_DEFINE ("DceLocalSocketFdFactory");
 
 namespace ns3 {
 

--- a/model/local-socket-fd.cc
+++ b/model/local-socket-fd.cc
@@ -31,7 +31,7 @@
 #include <exception>
 #include "poll.h"
 
-NS_LOG_COMPONENT_DEFINE ("LocalSocketFd");
+NS_LOG_COMPONENT_DEFINE ("DceLocalSocketFd");
 
 namespace ns3 {
 TypeId

--- a/model/local-stream-socket-fd.cc
+++ b/model/local-stream-socket-fd.cc
@@ -35,7 +35,7 @@
 #include "ns3/simulator.h"
 #include "file-usage.h"
 
-NS_LOG_COMPONENT_DEFINE ("LocalStreamSocketFd");
+NS_LOG_COMPONENT_DEFINE ("DceLocalStreamSocketFd");
 
 namespace ns3 {
 TypeId

--- a/model/ns3-socket-fd-factory.cc
+++ b/model/ns3-socket-fd-factory.cc
@@ -32,7 +32,7 @@
 #include <netpacket/packet.h>
 #include <net/ethernet.h>
 
-NS_LOG_COMPONENT_DEFINE ("Ns3SocketFdFactory");
+NS_LOG_COMPONENT_DEFINE ("DceNs3SocketFdFactory");
 
 namespace ns3 {
 

--- a/model/pipe-fd.cc
+++ b/model/pipe-fd.cc
@@ -26,7 +26,7 @@
 #include <errno.h>
 #include <fcntl.h>
 
-NS_LOG_COMPONENT_DEFINE ("PipeFd");
+NS_LOG_COMPONENT_DEFINE ("DcePipeFd");
 
 #define PIPE_CAPACITY 65536
 

--- a/model/process-delay-model.cc
+++ b/model/process-delay-model.cc
@@ -27,7 +27,7 @@
 namespace ns3 {
 
 NS_OBJECT_ENSURE_REGISTERED (ProcessDelayModel);
-NS_LOG_COMPONENT_DEFINE ("ProcessDelayModel");
+NS_LOG_COMPONENT_DEFINE ("DceProcessDelayModel");
 
 TypeId
 ProcessDelayModel::GetTypeId (void)

--- a/model/pthread-fiber-manager.cc
+++ b/model/pthread-fiber-manager.cc
@@ -42,7 +42,7 @@
 
 namespace ns3 {
 
-NS_LOG_COMPONENT_DEFINE ("PthreadFiberManager");
+NS_LOG_COMPONENT_DEFINE ("DcePthreadFiberManager");
 
 enum PthreadFiberState
 {

--- a/model/rr-task-scheduler.cc
+++ b/model/rr-task-scheduler.cc
@@ -20,7 +20,7 @@
 #include "rr-task-scheduler.h"
 #include "ns3/log.h"
 
-NS_LOG_COMPONENT_DEFINE ("RrTaskScheduler");
+NS_LOG_COMPONENT_DEFINE ("DceRrTaskScheduler");
 
 namespace ns3 {
 

--- a/model/task-manager.cc
+++ b/model/task-manager.cc
@@ -18,7 +18,7 @@
 
 namespace ns3 {
 
-NS_LOG_COMPONENT_DEFINE ("TaskManager");
+NS_LOG_COMPONENT_DEFINE ("DceTaskManager");
 NS_OBJECT_ENSURE_REGISTERED (TaskManager);
 
 

--- a/model/unix-datagram-socket-fd.cc
+++ b/model/unix-datagram-socket-fd.cc
@@ -45,7 +45,7 @@
 #include <arpa/inet.h>
 #include <linux/if_arp.h>
 #include <poll.h>
-NS_LOG_COMPONENT_DEFINE ("UnixDatagramSocketFd");
+NS_LOG_COMPONENT_DEFINE ("DceUnixDatagramSocketFd");
 
 namespace ns3 {
 

--- a/model/unix-fd.cc
+++ b/model/unix-fd.cc
@@ -6,7 +6,7 @@
 #include <fcntl.h>
 #include <errno.h>
 
-NS_LOG_COMPONENT_DEFINE ("UnixFd");
+NS_LOG_COMPONENT_DEFINE ("DceUnixFd");
 
 namespace ns3 {
 

--- a/model/unix-file-fd.cc
+++ b/model/unix-file-fd.cc
@@ -11,7 +11,7 @@
 #include "dce-node-context.h"
 #include "poll.h"
 
-NS_LOG_COMPONENT_DEFINE ("UnixFileFd");
+NS_LOG_COMPONENT_DEFINE ("DceUnixFileFd");
 
 namespace ns3 {
 

--- a/model/unix-socket-fd.cc
+++ b/model/unix-socket-fd.cc
@@ -47,7 +47,7 @@
 #include <linux/netlink.h>
 #include <sys/ioctl.h>
 
-NS_LOG_COMPONENT_DEFINE ("UnixSocketFd");
+NS_LOG_COMPONENT_DEFINE ("DceUnixSocketFd");
 
 namespace ns3 {
 

--- a/model/unix-stream-socket-fd.cc
+++ b/model/unix-stream-socket-fd.cc
@@ -12,7 +12,7 @@
 #include <fcntl.h>
 #include "file-usage.h"
 
-NS_LOG_COMPONENT_DEFINE ("UnixStreamSocketFd");
+NS_LOG_COMPONENT_DEFINE ("DceUnixStreamSocketFd");
 
 namespace ns3 {
 

--- a/model/unix-timer-fd.cc
+++ b/model/unix-timer-fd.cc
@@ -9,7 +9,7 @@
 #include <sys/mman.h>
 #include <poll.h>
 
-NS_LOG_COMPONENT_DEFINE ("UnixTimerFd");
+NS_LOG_COMPONENT_DEFINE ("DceUnixTimerFd");
 
 namespace ns3 {
 

--- a/model/utils.cc
+++ b/model/utils.cc
@@ -18,7 +18,7 @@
 #include "ns3/global-value.h"
 #include "ns3/uinteger.h"
 
-NS_LOG_COMPONENT_DEFINE ("ProcessUtils");
+NS_LOG_COMPONENT_DEFINE ("DceProcessUtils");
 
 namespace ns3 {
 

--- a/model/wait-queue.cc
+++ b/model/wait-queue.cc
@@ -28,7 +28,7 @@
 #include "utils.h"
 #include <map>
 
-NS_LOG_COMPONENT_DEFINE ("WaitQueue");
+NS_LOG_COMPONENT_DEFINE ("DceWaitQueue");
 
 namespace ns3 {
 WaitQueueEntry::WaitQueueEntry ()

--- a/model/waiter.cc
+++ b/model/waiter.cc
@@ -28,7 +28,7 @@
 #include "ns3/assert.h"
 #include <errno.h>
 
-NS_LOG_COMPONENT_DEFINE ("Waiter");
+NS_LOG_COMPONENT_DEFINE ("DceWaiter");
 
 namespace ns3 {
 

--- a/myscripts/ccn-mt1/ccn-mt1.cc
+++ b/myscripts/ccn-mt1/ccn-mt1.cc
@@ -25,7 +25,7 @@
 
 using namespace ns3;
 
-NS_LOG_COMPONENT_DEFINE ("FirstScriptExample");
+NS_LOG_COMPONENT_DEFINE ("DceFirstScriptExample");
 
 void
 CreateReadme ()

--- a/netlink/netlink-message-route.cc
+++ b/netlink/netlink-message-route.cc
@@ -74,6 +74,7 @@ NetlinkPayload::GetTypeId (void)
 {
   static TypeId tid = TypeId ("ns3::NetlinkPayload")
     .SetParent<ObjectBase> ()
+    .SetGroupName ("Netlink")
   ;
   return tid;
 }
@@ -112,6 +113,7 @@ GeneralMessage::GetTypeId (void)
 {
   static TypeId tid = TypeId ("ns3::GeneralMessage")
     .SetParent<NetlinkPayload> ()
+    .SetGroupName ("Netlink")
     .AddConstructor<GeneralMessage> ()
   ;
   return tid;

--- a/netlink/netlink-message.cc
+++ b/netlink/netlink-message.cc
@@ -23,7 +23,7 @@
 #include "ns3/address-utils.h"
 #include "ns3/log.h"
 
-NS_LOG_COMPONENT_DEFINE ("NetlinkMessage");
+NS_LOG_COMPONENT_DEFINE ("DceNetlinkMessage");
 
 namespace ns3 {
 

--- a/netlink/netlink-socket-factory.cc
+++ b/netlink/netlink-socket-factory.cc
@@ -39,6 +39,7 @@ NetlinkSocketFactory::GetTypeId (void)
   static TypeId tid = TypeId ("ns3::NetlinkSocketFactory")
     .AddConstructor<NetlinkSocketFactory> ()
     .SetParent<SocketFactory> ()
+    .SetGroupName ("Netlink")
   ;
   return tid;
 }

--- a/netlink/netlink-socket.cc
+++ b/netlink/netlink-socket.cc
@@ -98,6 +98,7 @@ NetlinkSocket::GetTypeId (void)
 {
   static TypeId tid = TypeId ("ns3::NetlinkSocket")
     .SetParent<Socket> ()
+    .SetGroupName ("Netlink")
     .AddConstructor<NetlinkSocket> ()
     .AddTraceSource ("Drop", "Drop packet due to receive buffer overflow",
                      MakeTraceSourceAccessor (&NetlinkSocket::m_dropTrace))

--- a/test/netlink-socket-test.cc
+++ b/test/netlink-socket-test.cc
@@ -43,7 +43,7 @@
 #include <list>
 
 
-NS_LOG_COMPONENT_DEFINE ("NetlinkSocketTest");
+NS_LOG_COMPONENT_DEFINE ("DceNetlinkSocketTest");
 
 namespace ns3 {
 


### PR DESCRIPTION
CAREFUL: DceAlloc was renamed to DceKingsleyAlloc while SimuAlloc became
DceAlloc.

This commit also creates a "Netlink" logging group.