### PR TITLE
Prefix all tests with dce

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -24,6 +24,7 @@ Tested platforms
 New user-visible features
 -------------------------
 - All logger names start with Dce. DceAlloc got renamed to DceKingsleyAlloc
+- All test names are prefixed with 'dce' (concerns process-manager and netlink-socket tests)
 
 Bugs fixed
 ----------

--- a/test/dce-manager-test.cc
+++ b/test/dce-manager-test.cc
@@ -166,7 +166,7 @@ private:
 #define FREEBSD_STACK  (1 << 2)
 
 DceManagerTestSuite::DceManagerTestSuite ()
-  : TestSuite ("process-manager", UNIT)
+  : TestSuite ("dce-process-manager", UNIT)
 {
   typedef struct
   {

--- a/test/netlink-socket-test.cc
+++ b/test/netlink-socket-test.cc
@@ -588,7 +588,7 @@ private:
 } g_netlinkTestSuite;
 
 NetlinkSocketTestSuite::NetlinkSocketTestSuite ()
-  : TestSuite ("netlink-socket", UNIT)
+  : TestSuite ("dce-netlink-socket", UNIT)
 {
   AddTestCase (new NetlinkSocketTestCase (), TestCase::QUICK);
 }


### PR DESCRIPTION
All tests but 2 are prefixed with DCE.
My hope is to improve convergence between ns3 and dce.

Having a consistant way to distinguish between dce tests and ns3 test make it easier to provide 3rd party programs such as this wrapper https://github.com/teto/ns3-testing (a unified interface to both ns3 and dce tests).
