### PR TITLE
Adds pcap export to netlink test.

### DIFF
--- a/netlink/netlink-socket.h
+++ b/netlink/netlink-socket.h
@@ -236,7 +236,7 @@ private:
   uint32_t m_Groups;
   Callback<void, Ipv4Address,uint8_t,uint8_t,uint8_t,uint32_t> m_icmpCallback;
 
-  TracedCallback<Ptr<const Packet> > m_promiscSnifferTrace;
+  TracedCallback<const Header&, Ptr<const Packet> > m_promiscSnifferTrace;
 };
 
 } //namespace ns3


### PR DESCRIPTION
This was already the case but this commit shows how to export it so that
it can be readable automatically in wireshark (via prepending linux
cooked headers).

This is the first thing I did during Gsoc. I believe it can very useful as debugging netlink is quite tricky.