### PR TITLE
Previous command could request userinput

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -18,7 +18,9 @@ dependencies:
         - ../bake/bake.py download
 
         # bake installs the master branch hence DCE will be install $CIRCLE_BRANCH
-        - git pull origin $CIRCLE_BRANCH/head:
+        - git fetch origin $CIRCLE_BRANCH/head:test
+            pwd: source/ns-3-dce
+        - git checkout test
             pwd: source/ns-3-dce
         - ../bake/bake.py build -j1 -vvv
 


### PR DESCRIPTION
... and generates a timeout. This should prevent it. Yet this only works
when fetching a PR and will fail on "master". Shall we write a specific
script for that ?

The old circleCI was not checking the PR, just master. I changed it so that it really tests the PRs with the code:
`git pull origin $CIRCLE_BRANCH/head` in circle.yml but now it doesn't work to test master as `git pull origin master/head` does not work. Any idea to have a holistic solution ?
I think this behavior is generating the timeout in https://github.com/direct-code-execution/ns-3-dce/pull/56
