### PR TITLE
Remove unused interface object

### DIFF
--- a/example/dce-iperf.cc
+++ b/example/dce-iperf.cc
@@ -49,9 +49,8 @@ int main (int argc, char *argv[])
   pointToPoint.SetDeviceAttribute ("DataRate", StringValue ("5Mbps"));
   pointToPoint.SetChannelAttribute ("Delay", StringValue ("1ms"));
 
-  NetDeviceContainer devices, devices2;
+  NetDeviceContainer devices;
   devices = pointToPoint.Install (nodes);
-  devices2 = pointToPoint.Install (nodes);
 
   DceManagerHelper dceManager;
   dceManager.SetTaskManagerAttribute ("FiberManagerType", StringValue ("UcontextFiberManager"));
@@ -92,8 +91,6 @@ int main (int argc, char *argv[])
   Ipv4AddressHelper address;
   address.SetBase ("10.1.1.0", "255.255.255.252");
   Ipv4InterfaceContainer interfaces = address.Assign (devices);
-  address.SetBase ("10.1.2.0", "255.255.255.252");
-  interfaces = address.Assign (devices2);
 
   // setup ip routes
   Ipv4GlobalRoutingHelper::PopulateRoutingTables ();

--- a/example/dce-iperf.cc
+++ b/example/dce-iperf.cc
@@ -107,6 +107,7 @@ int main (int argc, char *argv[])
 
   DceApplicationHelper dce;
   ApplicationContainer apps;
+  std::ostringstream serverIp;
 
   dce.SetStackSize (1 << 20);
 
@@ -115,7 +116,13 @@ int main (int argc, char *argv[])
   dce.ResetArguments ();
   dce.ResetEnvironment ();
   dce.AddArgument ("-c");
-  dce.AddArgument ("10.1.1.2");
+
+  // Extract server IP address
+  Ptr<Ipv4> ipv4Server = nodes.Get (1)->GetObject<Ipv4> ();
+  Ipv4Address serverAddress = ipv4Server->GetAddress (1, 0).GetLocal ();
+  serverAddress.Print (serverIp);
+
+  dce.AddArgument (serverIp.str());
   dce.AddArgument ("-i");
   dce.AddArgument ("1");
   dce.AddArgument ("--time");


### PR DESCRIPTION
This PR removes an extra device and interface object from dce-iperf.cc example. It also configures iperf client application with server IP dynamically.