### PR TITLE
__init__.py: look for ns3.29/ns3.28 libraries too

### DIFF
--- a/ns3waf/__init__.py
+++ b/ns3waf/__init__.py
@@ -143,7 +143,7 @@ def _check_win32(conf):
                 env['WL_SONAME_SUPPORTED'] = True
 
 
-ns3_versions = ['3-dev', '3.28', '3.27', '3.26', '3.25', '3.24', '3.23', '3.22', '3.21', '3.20', '3.19', '3.18', '3.17']
+ns3_versions = ['3-dev', '3.29', '3.28', '3.27', '3.26', '3.25', '3.24', '3.23', '3.22', '3.21', '3.20', '3.19', '3.18', '3.17']
 def _check_dependencies(conf, required, mandatory):
     found = []
     match_pkg = None


### PR DESCRIPTION
DCE could not find more recent versions of ns3.
Solves #80 