### PR TITLE
Fix Ubuntu 16.04 compilation errors

### DIFF
--- a/bindings/python/wscript
+++ b/bindings/python/wscript
@@ -5,6 +5,7 @@ import os
 import subprocess
 import shutil
 import sys
+import platform
 import ns3waf
 
 from waflib import Task, Options, Configure, TaskGen, Logs, Build, Utils, Errors
@@ -285,7 +286,10 @@ int main ()
 
     ## Check gccxml version
     try:
-        gccxml = conf.find_program('gccxml', var='GCCXML')
+        if platform.system() == 'Linux' and platform.platform().split('-')[6] == 'Ubuntu' and platform.platform().split('-')[7] == '16.04':
+            gccxml = conf.find_program('gccxml.real', var='GCCXML')
+        else:
+            gccxml = conf.find_program('gccxml', var='GCCXML')
     except WafError:
         gccxml = None
     if not gccxml:
@@ -294,7 +298,7 @@ int main ()
                                      "gccxml missing")
         return
 
-    gccxml_version_line = os.popen(gccxml + " --version").readline().strip()
+    gccxml_version_line = os.popen(gccxml[0] + " --version").readline().strip()
     m = re.match( "^GCC-XML version (\d\.\d(\.\d)?)$", gccxml_version_line)
     gccxml_version = m.group(1)
     gccxml_version_ok = ([int(s) for s in gccxml_version.split('.')] >= [0, 9])


### PR DESCRIPTION
After applying the patch from #80 still got compilations errors because 1) there was a list beeing used without the index and 2) the output from gccxml in Ubuntu 16.04 is different than expected (gccxml in 16.04 is a CastXML wrapper).

**Error 1:**

> File "/path/to/bake/source/ns-3-dce/bindings/python/wscript", line 297, in configure
>                 gccxml_version_line = os.popen(gccxml + " --version").readline().strip()
> TypeError: can only concatenate list (not "str") to list
> ()
> >> Building dce-linux-1.10 - Problem

**Error 2:**

> 
> File "/path/to/bake/source/ns-3-dce/bindings/python/wscript", line 299, in configure
>                 gccxml_version = m.group(1)
> AttributeError: 'NoneType' object has no attribute 'group'
> ()
> >> Building dce-linux-1.10 - Problem
