### PR TITLE
Fix struct timeval units in DCE poll

### DIFF
--- a/model/dce-poll.cc
+++ b/model/dce-poll.cc
@@ -36,7 +36,7 @@ int dce_poll (struct pollfd *fds, nfds_t nfds, int timeout)
     }
   else if (timeout > 0)
     {
-      endtime = Now () + MilliSeconds (timeout);
+      endtime = Now () + MicroSeconds (timeout);
     }
 
   for (uint32_t i = 0; i < nfds; ++i)
@@ -208,7 +208,7 @@ int dce_select (int nfds, fd_set *readfds, fd_set *writefds, fd_set *exceptfds,
 
   if (timeout)
     {
-      pollTo = timeout->tv_sec * 1000 + timeout->tv_usec / 1000;
+      pollTo = timeout->tv_sec * 1000000 + timeout->tv_usec / 1000;
     }
 
   int pollRet = dce_poll (pollFd, nfds, pollTo);


### PR DESCRIPTION
I would like to request a merge of this patch from Trish Deutsch, fixing this issue (option 2 in the discussion):
https://groups.google.com/forum/#!msg/ns-3-users/YhAcJh3Fv3U/wN-NlQw4BQAJ;context-place=forum/ns-3-users