### PR TITLE
Add Ioctl() support to LinuxSocketImpl

### DIFF
--- a/model/linux/linux-socket-impl.cc
+++ b/model/linux/linux-socket-impl.cc
@@ -543,6 +543,17 @@ LinuxSocketImpl::Getsockopt (int level, int optname,
   return ret;
 }
 
+int
+LinuxSocketImpl::Ioctl (unsigned long request, char* result_buffer)
+{
+  NS_LOG_FUNCTION (request << result_buffer);
+  uint16_t pid = EnterFakeTask ();
+  int ret = this->m_kernsock->Ioctl (request, result_buffer);
+  NS_LOG_INFO ("Ioctl returns " << ret << " errno " << Current ()->err);
+  LeaveFakeTask (pid);
+  return ret;
+}
+
 void
 LinuxSocketImpl::Poll ()
 {

--- a/model/linux/linux-socket-impl.h
+++ b/model/linux/linux-socket-impl.h
@@ -90,6 +90,7 @@ public:
   Ns3ToPosixConverter m_ns3toposix;
   PosixToNs3Converter m_posixtons3;
 
+  int Ioctl(unsigned long request, char *result_buffer);
 private:
   // Attributes set through UdpSocket base class
   virtual void SetRcvBufSize (uint32_t size);


### PR DESCRIPTION
Previously if you had a LinuxSocketImpl socket in your ns-3 master thread you could only call `socket->m_kernsock->Ioctl()` which would result in an error because there was no context, no thread for this task. 

This adds a wrapper method for LinuxSocketImpl objects that creates a FakeTask first, like for most other socket methods, and makes it possible to call `socket->Ioctl()`