### PR TITLE
Add Support for Github Actions CI

### DIFF
--- a/.github/workflows/dce-gaction-test.yml
+++ b/.github/workflows/dce-gaction-test.yml
@@ -1,0 +1,69 @@
+name: DCE Build
+on: [push, pull_request]
+
+# Anchors are not supported, so could not make use of modular workflow
+
+jobs : 
+  build:
+    strategy:
+      matrix:
+        job:           
+          # Used a personal Ubuntu-16.04 docker image since the previous once defaulted to root user, 
+          # so had to prefix all commands with sudo, and Github actions like checkout and caching throws permission error
+          # [ 'job-name'    , 'docker-image-name' ]
+          - [ 'ubuntu-16.04', 'parthpratim27/ns-3-dce:ubuntu-16.04' ]
+          # [ 'ubuntu-20.04', 'ns3dce/ubuntu20.04:0.1' ]
+
+    name : ${{ matrix.job[0] }}
+    runs-on : ubuntu-20.04 # This is ignored, but is a required field so is being set to this
+    container: ${{ matrix.job[1] }}
+
+    env:
+      BAKE_GIT: 'https://gitlab.com/nsnam/bake.git'
+      BAKE_CONFIG: 'dce-linux-dev'   # list-type, for each entry, -e {bake_config_entry} ... , will be added
+      GIT_HEAD_TRACK : '.git/HEAD'
+      HG_CHANGE_LOG : '.hg/store/00changelog.i'
+
+    steps:      
+      - name: Pull Source Tree 
+        uses: actions/checkout@v2   
+        with:     
+          path : target-dce-repo
+
+      - name: Download Bake 
+        run: git clone $BAKE_GIT bake 
+
+      - name: Configure Bake
+        run: ./bake/bake.py configure -e $BAKE_CONFIG      
+
+      - name: Download all required repos
+        run: ./bake/bake.py download -vvv       
+
+      - name: Copy Current ${{ github.event_name }} to source/ns-3-dce
+        run: cp -a target-dce-repo/. source/ns-3-dce      
+
+      # Below Caching saves 16 mins of build time (if an ns-3-dev build with same HEAD already exists)
+      # Couldn't add the same for net-next-nuse-4.4.0, because it would anyways still build the entire project after defconfig
+      - name: Load Build Cache for ns-3-dev
+        uses: actions/cache@v2
+        with:
+          id : cache-ns-3-dev
+          path: source/ns-3-dev
+          key: ${{ matrix.job[0] }}-src-build-ns-3-dev-${{ hashFiles('source/ns-3-dev/.git/HEAD') }}      
+
+      - name: Build Bake
+        run: ./bake/bake.py build -vvv
+
+      - name: Run Tests
+        run: |
+          cd source/ns-3-dce && ./test.py -r
+          find "testpy-output/" -type s -exec rm -f {} \;
+               
+      - name: Save Test Output Artifacts        
+        uses: actions/upload-artifact@v1
+        with: 
+          name: ${{ github.job }}-test-py-output
+          path: source/ns-3-dce/testpy-output
+
+
+

--- a/.github/workflows/dce-gaction-test.yml
+++ b/.github/workflows/dce-gaction-test.yml
@@ -11,8 +11,8 @@ jobs :
           # Used a personal Ubuntu-16.04 docker image since the previous once defaulted to root user, 
           # so had to prefix all commands with sudo, and Github actions like checkout and caching throws permission error
           # [ 'job-name'    , 'docker-image-name' ]
-          - [ 'ubuntu-16.04', 'parthpratim27/ns-3-dce:ubuntu-16.04' ]
-          # [ 'ubuntu-20.04', 'ns3dce/ubuntu20.04:0.1' ]
+          # [ 'ubuntu-16.04', 'parthpratim27/ns-3-dce:ubuntu-16.04' ]
+          - [ 'ubuntu-20.04', 'parthpratim27/ns-3-dce:ubuntu-20.04' ]
 
     name : ${{ matrix.job[0] }}
     runs-on : ubuntu-20.04 # This is ignored, but is a required field so is being set to this

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Github Actions Build Status](https://github.com/ParthPratim/ns-3-dce/workflows/DCE%20Build/badge.svg)](https://github.com/ParthPratim/ns-3-dce/actions)
 [![Build status](https://circleci.com/gh/direct-code-execution/ns-3-dce.svg?style=shield&circle-token=a9cf0c7e5e7a1d1a7ff2e2e5b341706fba3ccfb2)](https://circleci.com/gh/direct-code-execution/ns-3-dce)
 [![Documentation Status](https://readthedocs.org/projects/ns-3-dce/badge/?version=latest)](http://ns-3-dce.readthedocs.io/en/latest/?badge=latest)
 [![License](https://img.shields.io/badge/license-GPL-brightgreen.svg)](https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html)


### PR DESCRIPTION
Signed-off-by: Parth Pratim Chatterjee <parth27official@gmail.com>

Adds support for Github Actions CI/Test Workflow

### Key Features : 
1. Build Time :  
     1. Non-Cached : 36-42 minutes
     2. Cached : 24-26 minutes 
2. ns-3-dev HEAD commit based cache loading (saves around 16 mins of build time)
3. Simple list based job addition using job matrix 
4. Custom non-sudo docker 
5. Native target repo checkout usage
6. README badge for build status

### ToDo :
1. Add a feature to support dynamic bake configurations through a comma based delimiter. 

This PR  was made as a part of **Google Summer of Code 2021** for the project **Direct Code Execution Modernization**