### PR TITLE
Fix bug in dce_vasprintf

### DIFF
--- a/model/dce-stdio.cc
+++ b/model/dce-stdio.cc
@@ -808,11 +808,11 @@ int dce_vasprintf (char **strp, const char *fmt, va_list ap)
 
   if (ret > 0)
     {
-      char *tmp = (char*) dce_malloc (ret);
+      char *tmp = (char*) dce_malloc (ret + 1);
 
       if (tmp)
         {
-          memcpy (tmp, res, ret);
+          memcpy (tmp, res, ret + 1);
 
           *strp = tmp;
           free (res);


### PR DESCRIPTION
Hello, I'm woriking on porting FRRouting to dce. I've fixed a couple of bugs while working on it and I'd like to merge them.

The function dce_vasprintf calls to the system vasprintf, using a ret variable to ask for memory and copy the string that is returned by vasprintf. ret is the amount of bytes in the string without considering the termination character \0. For that reason there is a bug here and ret should be ret+1.