### PR TITLE
Fix bug in dce_internalClosedir

### DIFF
--- a/model/dce-dirent.cc
+++ b/model/dce-dirent.cc
@@ -93,7 +93,6 @@ int dce_internalClosedir (DIR *dirp, struct Thread *cur)
       if (ret == 0)
         {
           dce_close (-saveFd);
-          ds->fd = saveFd;
           remove_dir (dirp, cur);
         }
       else


### PR DESCRIPTION
Hello, I'm woriking on porting FRRouting to dce. I've fixed a couple of bugs while working on it and I'd like to merge them.

In the function dce_internalClosedir, there is a memory assignament (ds->fd = saveFd) that have been already freed by a call to closedir some lines above (ret = closedir (dirp)). The directory stream descriptor dirp is not available after this call causing a SEGFAULT.