### PR TITLE
Make it possible to use std::ofstream and adapt to NS-3 version 3.48

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 env:
-  NS3_VER: "3.46"
+  NS3_VER: "3.48"
 
 jobs:
   build:
@@ -18,8 +18,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - distro: ubuntu-22.04
-            image: ubuntu:22.04
           - distro: ubuntu-24.04
             image: ubuntu:24.04
           - distro: debian-trixie

--- a/helper/dce-manager-helper.cc
+++ b/helper/dce-manager-helper.cc
@@ -14,7 +14,7 @@
 #include "ipv4-linux.h"
 #include "dce-application-helper.h"
 #include "ns3/ipv4-routing-protocol.h"
-#include "ns3/ipv4-global-routing.h"
+#include "ns3/global-routing.h"
 #include <stdlib.h>
 #include <stdio.h>
 #include <limits.h>

--- a/model/dce-stdio.cc
+++ b/model/dce-stdio.cc
@@ -15,6 +15,7 @@
 #include <sys/mman.h>
 #include <string.h>
 #include <cstdarg>
+#include <map>
 
 NS_LOG_COMPONENT_DEFINE ("DceStdio");
 
@@ -171,6 +172,10 @@ FILE * dce_fdopen (int fildes, const char *mode)
   fp->_fileno = fildes;
   FILE *file = fopencookie(fp, mode, my_func);
   current->process->openStreams.push_back (file);
+  if (file != 0)
+    {
+      current->process->openStreamFds[file] = fildes;
+    }
   dce_fseek (file, dce_lseek (fildes, 0, SEEK_CUR), SEEK_SET);
 
   return file;
@@ -278,6 +283,7 @@ remove_stream (FILE *fp)
 {
   Thread *current = Current ();
   bool found = false;
+  current->process->openStreamFds.erase (fp);
   for (std::vector<FILE*>::iterator  i = current->process->openStreams.begin ();
        i != current->process->openStreams.end (); ++i)
     {
@@ -422,8 +428,14 @@ int dce_fileno (FILE *stream)
       return 2;
   }
 
-  // FIXME: Handle fopencookie things to. We need to detect those FILE*
-  // and return cookie->_fileno instead... But how?
+  // For fopencookie-backed streams, return the mapped DCE fd instead of the
+  // libc fileno() (which would return -1 since they have no real fd).
+  std::map<FILE *, int>::const_iterator it =
+    current->process->openStreamFds.find (stream);
+  if (it != current->process->openStreamFds.end ())
+    {
+      return it->second;
+    }
 
   int status = fileno (stream);
   if (status == -1)

--- a/model/freebsd/ipv4-freebsd.cc
+++ b/model/freebsd/ipv4-freebsd.cc
@@ -25,7 +25,7 @@
 #include "ns3/ipv4-static-routing-helper.h"
 #include "ns3/ipv4-global-routing-helper.h"
 #include "ns3/ipv4-interface.h"
-#include "ns3/ipv4-global-routing.h"
+#include "ns3/global-routing.h"
 #include "ns3/ipv4-routing-table-entry.h"
 #include "dce-application-helper.h"
 #include "freebsd-socket-fd-factory.h"

--- a/model/linux/ipv4-linux.cc
+++ b/model/linux/ipv4-linux.cc
@@ -26,7 +26,7 @@
 #include "ns3/ipv4-static-routing-helper.h"
 #include "ns3/ipv4-global-routing-helper.h"
 #include "ns3/ipv4-interface.h"
-#include "ns3/ipv4-global-routing.h"
+#include "ns3/global-routing.h"
 #include "ns3/ipv4-routing-table-entry.h"
 #include "linux-stack-helper.h"
 #include "linux-ipv4-raw-socket-factory-impl.h"

--- a/model/process.h
+++ b/model/process.h
@@ -140,6 +140,7 @@ struct Process
   // Key is the fd
   std::map<int,FileUsage *> openFiles;
   std::vector<FILE *> openStreams;
+  std::map<FILE *, int> openStreamFds; // Maps a fopencookie-backed stream to its DCE fd.
   std::vector<DIR *> openDirs;
   std::vector<SignalHandler> signalHandlers;
   std::vector<Thread *> threads;

--- a/netlink/netlink-socket-address.cc
+++ b/netlink/netlink-socket-address.cc
@@ -117,7 +117,7 @@ bool NetlinkSocketAddress::IsMatchingType (const Address &address)
 
 uint8_t NetlinkSocketAddress::GetType (void)
 {
-  static uint8_t type = Address::Register ();
+  static uint8_t type = Address::Register ("NetlinkSocketAddress", 8);
   return type;
 }
 

--- a/test/test-iostream.cc
+++ b/test/test-iostream.cc
@@ -1,7 +1,18 @@
 #include <sstream>
+#include <fstream>
 #include <string>
 #include <ios>
+#include <unistd.h>
 #include "test-macros.h"
+
+static std::string
+read_whole_file (const char *path)
+{
+  std::ifstream ifs (path);
+  std::ostringstream oss;
+  oss << ifs.rdbuf ();
+  return oss.str ();
+}
 
 template<typename T>
 static std::string
@@ -41,6 +52,39 @@ main (int argc, char *argv[])
     std::ostringstream oss;
     oss << "value=" << 42 << " done";
     TEST_ASSERT_EQUAL (oss.str (), std::string ("value=42 done"));
+  }
+
+  // std::ofstream: write to a file, close, read it back.
+  {
+    const char *path = "iostream-test.out";
+    unlink (path);
+
+    std::ofstream ofs;
+    ofs.open (path);
+    TEST_ASSERT (ofs.is_open ());
+    TEST_ASSERT (ofs.good ());
+    TEST_ASSERT ((bool) ofs);
+
+    ofs << "line1=" << 1 << "\n";
+    ofs << "pi=" << 3.5 << "\n";
+    ofs << "hex=" << std::hex << std::showbase << 255 << "\n";
+    TEST_ASSERT (ofs.good ());
+    ofs.close ();
+    TEST_ASSERT (!ofs.fail ());
+
+    std::string contents = read_whole_file (path);
+    TEST_ASSERT_EQUAL (contents, std::string ("line1=1\npi=3.5\nhex=0xff\n"));
+
+    unlink (path);
+  }
+
+  // std::ofstream opening a path that cannot be created must report failure.
+  {
+    std::ofstream bad;
+    bad.open ("no-such-dir/definitely-missing/status.new");
+    TEST_ASSERT (!bad);
+    TEST_ASSERT (bad.fail ());
+    bad.close ();
   }
 
   return 0;


### PR DESCRIPTION
Fix std::ofstream by returning real fd from fileno() for cookie streams. Also use latest NS-3 release. The ofstream test is vibe-coded, but it fail without the correction and is minimal enough.

I have verified that the DCE results for projects we run are still good and valid after the NS-3 version change (3.46 -> 3.48). I got cmake problems running Ubuntu 22.04, not worth the time to investigate and try to fix (my opinion).

Feel free to modify the changes I have made as much as you like (or ask me to improve things).